### PR TITLE
Finish Options View & RatingView

### DIFF
--- a/Shared/Data/Watched_It_.xcdatamodeld/Watched_It_.xcdatamodel/contents
+++ b/Shared/Data/Watched_It_.xcdatamodeld/Watched_It_.xcdatamodel/contents
@@ -15,4 +15,14 @@
         <attribute name="timestamp" attributeType="Date" defaultDateTimeInterval="695048340" usesScalarValueType="NO"/>
         <relationship name="identifiedItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="IdentifiedItemData" inverseName="mediaItem" inverseEntity="IdentifiedItemData"/>
     </entity>
+    <entity name="MediaOptionsData" representedClassName="MediaOptionsData" syncable="YES" codeGenerationType="class">
+        <attribute name="isFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="mediaId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="oid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="rating" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="subTitle" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <attribute name="watchList" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+    </entity>
 </model>

--- a/Shared/Models/Main/Movie.swift
+++ b/Shared/Models/Main/Movie.swift
@@ -34,6 +34,9 @@ struct Movie: Identifiable, Codable, Equatable {
     var voteAverage: Double
     var voteCount: Int
 //MARK: - Mappings
+    var preview: MediaPreview {
+        return MediaPreview(url: backdropPath?.large, title: title, popularity: popularity, subTitle: tagline, type: .movie(id: id))
+    }
     var duration: String? {
         guard let runtime else {return nil}
         let hours = runtime/60

--- a/Shared/Models/Main/TVShow.swift
+++ b/Shared/Models/Main/TVShow.swift
@@ -55,6 +55,9 @@ struct TVShow: Identifiable, Codable, Equatable {
     var ageRating: String {
         return (adult ? "R": "PG") + " Rated"
     }
+    var preview: MediaPreview {
+        return MediaPreview(url: backdropPath?.large, title: name, popularity: popularity, subTitle: tagline, type: .tvShow(id: id))
+    }
 }
 
 struct NetworkChannel: Identifiable, Codable, Equatable {

--- a/Shared/Models/MediaOptions.swift
+++ b/Shared/Models/MediaOptions.swift
@@ -1,0 +1,32 @@
+//
+//  MediaOptions.swift
+//  Watched It?
+//
+//  Created by Joe Maghzal on 29/01/2023.
+//
+
+import Foundation
+import DataStruct
+
+struct MediaOptions: Identifiable, Codable, Equatable {
+    var id: UUID?
+    var mediaId: Int
+    var isFavorite: Bool
+    var watchList: Bool
+    var name: String
+    var rating: Int?
+    var type: MediaType
+    var subTitle: String?
+}
+
+//MARK: - Datable
+extension MediaOptions: Datable {
+    static var empty = MediaOptions(mediaId: 0, isFavorite: false, watchList: false, name: "", type: .movie)
+    static var modelData = ModelData<MediaOptions>()
+    static func map(from object: MediaOptionsData?) -> Self? {
+        guard let object, let mediaType = MediaType(rawValue: object.type ?? "") else {
+            return nil
+        }
+        return MediaOptions(id: object.oid, mediaId: Int(object.mediaId), isFavorite: object.isFavorite, watchList: object.watchList, name: object.name ?? "", rating: Int(object.rating), type: mediaType, subTitle: object.subTitle)
+    }
+}

--- a/Shared/Models/Utitlities/MediaType.swift
+++ b/Shared/Models/Utitlities/MediaType.swift
@@ -1,0 +1,47 @@
+//
+//  MediaType.swift
+//  Watched It?
+//
+//  Created by Joe Maghzal on 29/01/2023.
+//
+
+import Foundation
+import DataStruct
+
+enum MediaType: String, Codable {
+    case all = "all"
+    case movie = "movie"
+    case tv = "tv"
+    case person = "person"
+    var title: String {
+        switch self {
+            case .all:
+                return "All"
+            case .movie:
+                return "Movies"
+            case .tv:
+                return "TV Shows"
+            case .person:
+                return "People"
+        }
+    }
+    var image: String {
+        switch self {
+            case .all:
+                return "All"
+            case .movie:
+                return "theatermasks.fill"
+            case .tv:
+                return "tv.fill"
+            case .person:
+                return "person.fill"
+        }
+    }
+}
+
+//MARK: - DatableValue
+extension MediaType: DatableValue {
+    var dataValue: Any {
+        return rawValue
+    }
+}

--- a/Shared/Network/NetworkConfigurations.swift
+++ b/Shared/Network/NetworkConfigurations.swift
@@ -23,7 +23,7 @@ class NetworkLayer: NetworkConfigurations {
         return decoder
     }
     func reprocess(url: URL?) -> URL? {
-        let route = URLRoute(from: URLQueryItem(name: "api_key", value: ""))
+        let route = URLRoute(from: URLQueryItem(name: "api_key", value: Constants.apiKey))
             .appending(URLQueryItem(name: "language", value: "en-US"))
         return route.applied(to: url)
     }

--- a/Shared/Network/Routes/DiscoveryRoute.swift
+++ b/Shared/Network/Routes/DiscoveryRoute.swift
@@ -43,34 +43,3 @@ enum TimeWindow: String {
     case day = "day"
     case week = "week"
 }
-
-enum MediaType: String, Codable {
-    case all = "all"
-    case movie = "movie"
-    case tv = "tv"
-    case person = "person"
-    var title: String {
-        switch self {
-            case .all:
-                return "All"
-            case .movie:
-                return "Movies"
-            case .tv:
-                return "TV Shows"
-            case .person:
-                return "People"
-        }
-    }
-    var image: String {
-        switch self {
-            case .all:
-                return "All"
-            case .movie:
-                return "theatermasks.fill"
-            case .tv:
-                return "tv.fill"
-            case .person:
-                return "person.fill"
-        }
-    }
-}

--- a/Watched It?.xcodeproj/project.pbxproj
+++ b/Watched It?.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		194811A0297801D100539F95 /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1948119F297801D100539F95 /* ResultView.swift */; };
 		194811A229781A1600539F95 /* OptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194811A129781A1600539F95 /* OptionsView.swift */; };
 		1952D89E298682D600398216 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1952D89D298682D600398216 /* Constants.swift */; };
+		1952D8A329868FDB00398216 /* MediaOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1952D8A229868FDB00398216 /* MediaOptions.swift */; };
+		1952D8A52986911400398216 /* MediaType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1952D8A42986911400398216 /* MediaType.swift */; };
 		196C0DF32975CC0600D6FC9B /* TVShowRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C0DF22975CC0600D6FC9B /* TVShowRoute.swift */; };
 		196C0DF52975CC5800D6FC9B /* TVShowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C0DF42975CC5800D6FC9B /* TVShowView.swift */; };
 		196C0DF82975CC7300D6FC9B /* TVShowViewConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196C0DF72975CC7300D6FC9B /* TVShowViewConfig.swift */; };
@@ -84,6 +86,8 @@
 		19B0C1BF2985A79700B79CFB /* PersonInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B0C1BE2985A79700B79CFB /* PersonInfo.swift */; };
 		19B0C1C12985AB0200B79CFB /* SwipeActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B0C1C02985AB0200B79CFB /* SwipeActions.swift */; };
 		19B0C1C32985ABA500B79CFB /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B0C1C22985ABA500B79CFB /* Binding.swift */; };
+		19D627D12986A67800E4EBE7 /* OptionsViewConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D627D02986A67800E4EBE7 /* OptionsViewConfig.swift */; };
+		19D627D42986ABDF00E4EBE7 /* RatingViewConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D627D32986ABDF00E4EBE7 /* RatingViewConfig.swift */; };
 		19E9BC0729731D32003DAFD4 /* DiscoverDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E9BC0629731D32003DAFD4 /* DiscoverDetailsView.swift */; };
 		19E9BC0A29731F2D003DAFD4 /* DiscoverDetailsViewConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E9BC0929731F2D003DAFD4 /* DiscoverDetailsViewConfig.swift */; };
 		19E9BC0C297327B1003DAFD4 /* MovieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E9BC0B297327B1003DAFD4 /* MovieView.swift */; };
@@ -148,6 +152,8 @@
 		1948119F297801D100539F95 /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
 		194811A129781A1600539F95 /* OptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsView.swift; sourceTree = "<group>"; };
 		1952D89D298682D600398216 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		1952D8A229868FDB00398216 /* MediaOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaOptions.swift; sourceTree = "<group>"; };
+		1952D8A42986911400398216 /* MediaType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaType.swift; sourceTree = "<group>"; };
 		196C0DF22975CC0600D6FC9B /* TVShowRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVShowRoute.swift; sourceTree = "<group>"; };
 		196C0DF42975CC5800D6FC9B /* TVShowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVShowView.swift; sourceTree = "<group>"; };
 		196C0DF72975CC7300D6FC9B /* TVShowViewConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVShowViewConfig.swift; sourceTree = "<group>"; };
@@ -183,6 +189,8 @@
 		19B0C1BE2985A79700B79CFB /* PersonInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonInfo.swift; sourceTree = "<group>"; };
 		19B0C1C02985AB0200B79CFB /* SwipeActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeActions.swift; sourceTree = "<group>"; };
 		19B0C1C22985ABA500B79CFB /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
+		19D627D02986A67800E4EBE7 /* OptionsViewConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsViewConfig.swift; sourceTree = "<group>"; };
+		19D627D32986ABDF00E4EBE7 /* RatingViewConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingViewConfig.swift; sourceTree = "<group>"; };
 		19E9BC0629731D32003DAFD4 /* DiscoverDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverDetailsView.swift; sourceTree = "<group>"; };
 		19E9BC0929731F2D003DAFD4 /* DiscoverDetailsViewConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverDetailsViewConfig.swift; sourceTree = "<group>"; };
 		19E9BC0B297327B1003DAFD4 /* MovieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieView.swift; sourceTree = "<group>"; };
@@ -289,6 +297,7 @@
 				1909694E2972AF3D00BCBEB0 /* Gender.swift */,
 				19B0C1AB298532FB00B79CFB /* Superposition.swift */,
 				190969482972AD2500BCBEB0 /* PageableResponse.swift */,
+				1952D8A42986911400398216 /* MediaType.swift */,
 			);
 			path = Utitlities;
 			sourceTree = "<group>";
@@ -314,12 +323,12 @@
 				1900D689297BF49300F1D51A /* Reviews */,
 				1900D696297BFF4500F1D51A /* Person */,
 				19B0C1AF29853A1A00B79CFB /* PersonCredits */,
+				19D627CF2986A66F00E4EBE7 /* Options */,
+				19D627D22986ABD700E4EBE7 /* Rating */,
 				191D2ADF296F349C0011021D /* SearchBarView.swift */,
 				19E9BC102973F4C9003DAFD4 /* PlaceholderView.swift */,
-				19E9BC2D29742F0E003DAFD4 /* RatingView.swift */,
 				199EEA432974472A00B49975 /* SlidingImageView.swift */,
 				1948119F297801D100539F95 /* ResultView.swift */,
-				194811A129781A1600539F95 /* OptionsView.swift */,
 			);
 			path = More;
 			sourceTree = "<group>";
@@ -399,6 +408,7 @@
 			children = (
 				1984DFA3296CA10C003E5AD1 /* IdentifiedItem.swift */,
 				1984DFA6296CA342003E5AD1 /* MediaItem.swift */,
+				1952D8A229868FDB00398216 /* MediaOptions.swift */,
 				190969612972F95100BCBEB0 /* ImageURL.swift */,
 				19B0C1BB2985A78C00B79CFB /* Info */,
 				19E9BC2529741882003DAFD4 /* Previews */,
@@ -543,6 +553,24 @@
 			path = Info;
 			sourceTree = "<group>";
 		};
+		19D627CF2986A66F00E4EBE7 /* Options */ = {
+			isa = PBXGroup;
+			children = (
+				194811A129781A1600539F95 /* OptionsView.swift */,
+				19D627D02986A67800E4EBE7 /* OptionsViewConfig.swift */,
+			);
+			name = Options;
+			sourceTree = "<group>";
+		};
+		19D627D22986ABD700E4EBE7 /* Rating */ = {
+			isa = PBXGroup;
+			children = (
+				19E9BC2D29742F0E003DAFD4 /* RatingView.swift */,
+				19D627D32986ABDF00E4EBE7 /* RatingViewConfig.swift */,
+			);
+			name = Rating;
+			sourceTree = "<group>";
+		};
 		19E9BC0829731F1F003DAFD4 /* Details */ = {
 			isa = PBXGroup;
 			children = (
@@ -684,6 +712,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1900D695297BFF4200F1D51A /* PersonView.swift in Sources */,
+				1952D8A329868FDB00398216 /* MediaOptions.swift in Sources */,
 				19E9BC0A29731F2D003DAFD4 /* DiscoverDetailsViewConfig.swift in Sources */,
 				1984DFA2296C9F9D003E5AD1 /* IdentifyViewConfig.swift in Sources */,
 				19B0C1B42985564200B79CFB /* SearchResultsViewConfig.swift in Sources */,
@@ -714,6 +743,7 @@
 				1900D69C297C0FC600F1D51A /* PersonCredits.swift in Sources */,
 				1988D7DB296C9AF20078EE91 /* RootView.swift in Sources */,
 				19E9BC2A29741962003DAFD4 /* CastCrewDetailsViewConfig.swift in Sources */,
+				19D627D12986A67800E4EBE7 /* OptionsViewConfig.swift in Sources */,
 				19E9BC2E29742F0E003DAFD4 /* RatingView.swift in Sources */,
 				19E9BC132973F60A003DAFD4 /* HeaderView.swift in Sources */,
 				199EEA462974474D00B49975 /* Extensions.swift in Sources */,
@@ -734,6 +764,7 @@
 				1909694B2972AE4A00BCBEB0 /* Credits.swift in Sources */,
 				1909693B2972A35700BCBEB0 /* Movie.swift in Sources */,
 				19E9BC2C29741B6B003DAFD4 /* CreditsCellView.swift in Sources */,
+				1952D8A52986911400398216 /* MediaType.swift in Sources */,
 				19E9BC152973F624003DAFD4 /* BackButtonView.swift in Sources */,
 				19E9BC182973F6D0003DAFD4 /* MovieViewConfig.swift in Sources */,
 				19B0C1BA2985A78A00B79CFB /* MovieInfo.swift in Sources */,
@@ -767,6 +798,7 @@
 				19E9BC1D29740084003DAFD4 /* YouTubeView.swift in Sources */,
 				19B0C1B12985563300B79CFB /* SearchResultsView.swift in Sources */,
 				19E9BC1F29740DF9003DAFD4 /* CreditsView.swift in Sources */,
+				19D627D42986ABDF00E4EBE7 /* RatingViewConfig.swift in Sources */,
 				1900D69A297C0C5E00F1D51A /* PersonRoute.swift in Sources */,
 				191D2AE6296F3D270011021D /* MediaView.swift in Sources */,
 				199EEA442974472A00B49975 /* SlidingImageView.swift in Sources */,
@@ -998,8 +1030,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/TimmysApp/DataStruct";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = master;
+				kind = branch;
 			};
 		};
 		1984DF95296C9C92003E5AD1 /* XCRemoteSwiftPackageReference "MediaUI" */ = {

--- a/Watched It?/Views/More/MovieView.swift
+++ b/Watched It?/Views/More/MovieView.swift
@@ -94,7 +94,7 @@ struct MovieView: View {
                             Spacer()
                         }.padding(.top, -15)
                         HStack(spacing: 10) {
-                            RatingView(media: .movie(id: movie.id))
+                            RatingView(media: movie.preview)
                             Button(action: {
                             }) {
                                 HStack {
@@ -180,7 +180,7 @@ struct MovieView: View {
         }.bindNetwork()
         .background(Color.background.gradient).toolbar(.hidden, for: .navigationBar)
         .sheet(isPresented: $config.showingDetails) {
-            OptionsView(url: config.movie?.backdropPath?.large ?? config.movie?.posterPath?.medium, title: config.movie?.title ?? "", tagline: config.movie?.tagline)
+            OptionsView(media: config.movie?.preview)
         }.navigationDestination(for: Credits.self) { credits in
             CreditsDetailsView(credits: credits)
         }.navigationDestination(for: CreditsPreview.PreviewType.self) { item in

--- a/Watched It?/Views/More/OptionsView.swift
+++ b/Watched It?/Views/More/OptionsView.swift
@@ -7,29 +7,31 @@
 
 import SwiftUI
 import MediaUI
+import DataStruct
 
 struct OptionsView: View {
     @Environment(\.dismiss) var dismiss
-    var url: URL?
-    var title: String
-    var tagline: String?
+    @State var config: OptionsViewConfig
+    init(media: MediaPreview?) {
+        _config = State(initialValue: OptionsViewConfig(media: media))
+    }
     var body: some View {
         VStack(spacing: 10) {
             HStack(alignment: .center) {
-                NetworkImage(url: url)
+                NetworkImage(url: config.media?.url)
                     .isResizable()
                     .frame(height: 40)
                     .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                     .shadow(color: .darkShadow, radius: 6, y: 8)
                 VStack(alignment: .leading, spacing: 0) {
-                    Text(title)
+                    Text(config.media?.title ?? "")
                         .font(.callout)
                         .fontWeight(.semibold)
-                    Text(tagline ?? "")
+                    Text(config.media?.subTitle ?? "")
                         .foregroundColor(.gray)
                         .font(.caption2)
                         .fontWeight(.medium)
-                        .hidden(tagline?.isEmpty == true)
+                        .hidden(config.media?.subTitle?.isEmpty == true)
                 }
                 Spacer()
                 Button(action: {
@@ -45,11 +47,11 @@ struct OptionsView: View {
                 .fill(Color.gray)
                 .frame(height: 1)
             VStack(spacing: 10) {
-                OptionView(image: "bookmark", title: "Add to Watchlist", color: .tint) {
-                    
+                OptionView(image: config.options?.watchList ?? false ? "bookmark.fill": "bookmark", title: config.options?.watchList ?? false ? "Remove from Watchlist": "Add to Watchlist", color: .tint) {
+                    config.toggleWatchlist()
                 }
-                OptionView(image: "heart", title: "Add to favorites", color: .pink) {
-                    
+                OptionView(image: config.options?.isFavorite ?? false ? "heart.fill": "heart", title: config.options?.isFavorite ?? false ? "Remove from Favorites": "Add to Favorites", color: .pink) {
+                    config.toggleFavorite()
                 }
                 OptionView(image: "square.and.arrow.up.fill", title: "Share", color: .inverseBasic) {
                     
@@ -61,6 +63,9 @@ struct OptionsView: View {
         .background(Color.sheetBackground)
         .presentationDragIndicator(.visible)
         .presentationDetents([.height(250)])
+        .task {
+            config.fetch()
+        }
     }
 }
 

--- a/Watched It?/Views/More/OptionsViewConfig.swift
+++ b/Watched It?/Views/More/OptionsViewConfig.swift
@@ -1,0 +1,42 @@
+//
+//  OptionsViewConfig.swift
+//  Watched It?
+//
+//  Created by Joe Maghzal on 29/01/2023.
+//
+
+import Foundation
+import DataStruct
+
+struct OptionsViewConfig {
+//MARK: - Properties
+    var options: MediaOptions?
+    var media: MediaPreview?
+//MARK: - Functions
+    mutating func toggleWatchlist() {
+        guard let media else {return}
+        if options != nil {
+            options?.watchList.toggle()
+            options?.update()
+        }else {
+            let newOptions = MediaOptions(mediaId: media.type.id, isFavorite: false, watchList: true, name: media.title, type: media.type.type, subTitle: media.subTitle)
+            newOptions.save()
+            options = newOptions
+        }
+    }
+    mutating func toggleFavorite() {
+        guard let media else {return}
+        if options != nil {
+            options?.isFavorite.toggle()
+            options?.update()
+        }else {
+            let newOptions = MediaOptions(mediaId: media.type.id, isFavorite: true, watchList: false, name: media.title, type: media.type.type, subTitle: media.subTitle)
+            newOptions.save()
+            options = newOptions
+        }
+    }
+    mutating func fetch() {
+        guard let media else {return}
+        options = try? MediaOptions.rawFetch(with: NSPredicate(format: "mediaId == %@ && type == %@", String(media.type.id), media.type.type.rawValue)).first
+    }
+}

--- a/Watched It?/Views/More/RatingView.swift
+++ b/Watched It?/Views/More/RatingView.swift
@@ -6,20 +6,26 @@
 //
 
 import SwiftUI
+import DataStruct
 
 struct RatingView: View {
-    @State var rating = 0
-    var media: MediaPreview.PreviewType
+    @State var config: RatingViewConfig
+    init(media: MediaPreview) {
+        _config = State(initialValue: RatingViewConfig(media: media))
+    }
+    init(rating: Int) {
+        _config = State(initialValue: RatingViewConfig(rating: rating))
+    }
     var body: some View {
         VStack {
             HStack(spacing: 0) {
                 ForEach(0..<10) { index in
                     Button(action: {
-                        rating = index + 1
+                        config.rate(index + 1)
                     }) {
-                        Image(systemName: rating >= (index + 1) ? "star.fill": "star")
+                        Image(systemName: config.rating >= (index + 1) ? "star.fill": "star")
                             .foregroundColor(.yellow)
-                    }
+                    }.disabled(config.media == nil)
                 }
             }
         }.padding(5)
@@ -27,5 +33,8 @@ struct RatingView: View {
         .background(Color.basic.opacity(0.7))
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         .shadow(color: .darkShadow, radius: 6)
+        .task {
+            config.fetch()
+        }
     }
 }

--- a/Watched It?/Views/More/RatingViewConfig.swift
+++ b/Watched It?/Views/More/RatingViewConfig.swift
@@ -1,0 +1,33 @@
+//
+//  RatingViewConfig.swift
+//  Watched It?
+//
+//  Created by Joe Maghzal on 29/01/2023.
+//
+
+import Foundation
+
+struct RatingViewConfig {
+//MARK: - Properties
+    var rating = 0
+    var options: MediaOptions?
+    var media: MediaPreview?
+//MARK: - Functions
+    mutating func fetch() {
+        guard let media else {return}
+        options = try? MediaOptions.rawFetch(with: NSPredicate(format: "mediaId == %@ && type == %@", String(media.type.id), media.type.type.rawValue)).first
+        rating = options?.rating ?? 0
+    }
+    mutating func rate(_ value: Int) {
+        guard let media else {return}
+        rating = value
+        if options != nil {
+            options?.rating = value
+            options?.update()
+        }else {
+            let newOptions = MediaOptions(mediaId: media.type.id, isFavorite: false, watchList: false, name: media.title, rating: value, type: media.type.type, subTitle: media.subTitle)
+            newOptions.save()
+            options = newOptions
+        }
+    }
+}

--- a/Watched It?/Views/More/ReviewsCellView.swift
+++ b/Watched It?/Views/More/ReviewsCellView.swift
@@ -24,7 +24,7 @@ struct ReviewCellView: View {
                         .background(Color.accentColor.opacity(0.3))
                         .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
                         .padding(.bottom, 5)
-                        RatingView(rating: review.authorDetails.rating ?? 0, media: .movie(id: 0))
+                        RatingView(rating: review.authorDetails.rating ?? 0)
                             .clipShape(ConfigurableRoundedRectangle(corners: [UIRectCorner.topLeft, .topRight], radius: 9))
                     }
                     HStack {

--- a/Watched It?/Views/More/TVShowView.swift
+++ b/Watched It?/Views/More/TVShowView.swift
@@ -97,7 +97,7 @@ struct TVShowView: View {
                             Spacer()
                         }.padding(.top, -15)
                         HStack(spacing: 10) {
-                            RatingView(media: .tvShow(id: tvShow.id))
+                            RatingView(media: tvShow.preview)
                             NavigationLink(value: tvShow.id) {
                                 HStack {
                                     Text("Reviews")
@@ -183,7 +183,7 @@ struct TVShowView: View {
         .background(Color.background.gradient)
         .toolbar(.hidden, for: .navigationBar)
         .sheet(isPresented: $config.showingDetails) {
-            OptionsView(url: config.tvShow?.backdropPath?.large ?? config.tvShow?.posterPath?.medium, title: config.tvShow?.name ?? "", tagline: config.tvShow?.tagline)
+            OptionsView(media: config.tvShow?.preview)
         }.navigationDestination(for: Credits.self) { credits in
             CreditsDetailsView(credits: credits)
         }.navigationDestination(for: Int.self) { id in


### PR DESCRIPTION
Added the following changes:

1. Toggle the `watchList` property of a Movie/TVShow if it was previously saved;
2. Save the new options in `CoreData` if nothing is found;
3. Update the `rating` property of a Movie/TVShow if it was previously saved;
4. Save the new rating in `CoreData` if nothing is found.